### PR TITLE
Bugfix/mg ema 136697

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SwiftyRSA
 =========
 
-**Maintainer(s):** [@ldiqual](https://github.com/ldiqual)
+**Maintainer(s):** [@starback](https://github.com/starback)
 
 [![](https://img.shields.io/cocoapods/v/SwiftyRSA.svg)](https://cocoapods.org/pods/SwiftyRSA)
 ![](https://img.shields.io/badge/carthage-compatible-brightgreen.svg)

--- a/Source/ClearMessage.swift
+++ b/Source/ClearMessage.swift
@@ -91,7 +91,7 @@ public class ClearMessage: Message {
             idx += maxChunkSize
         }
         
-        let encryptedData = Data(bytes: UnsafePointer<UInt8>(encryptedDataBytes), count: encryptedDataBytes.count)
+        let encryptedData = Data(bytes: encryptedDataBytes, count: encryptedDataBytes.count)
         return EncryptedMessage(data: encryptedData)
     }
     
@@ -126,7 +126,7 @@ public class ClearMessage: Message {
             throw SwiftyRSAError.signatureCreateFailed(status: status)
         }
         
-        let signatureData = Data(bytes: UnsafePointer<UInt8>(signatureBytes), count: signatureBytes.count)
+        let signatureData = Data(bytes: signatureBytes, count: signatureBytes.count)
         return Signature(data: signatureData)
     }
     

--- a/Source/EncryptedMessage.swift
+++ b/Source/EncryptedMessage.swift
@@ -53,7 +53,7 @@ public class EncryptedMessage: Message {
             idx += blockSize
         }
         
-        let decryptedData = Data(bytes: UnsafePointer<UInt8>(decryptedDataBytes), count: decryptedDataBytes.count)
+        let decryptedData = Data(bytes: decryptedDataBytes, count: decryptedDataBytes.count)
         return ClearMessage(data: decryptedData)
     }
 }

--- a/Source/SwiftyRSA.swift
+++ b/Source/SwiftyRSA.swift
@@ -151,7 +151,7 @@ public enum SwiftyRSA {
     
     static func addKey(_ keyData: Data, isPublic: Bool, tag: String) throws ->  SecKey {
         
-        var keyData = keyData
+        let keyData = keyData
         
         guard let tagData = tag.data(using: .utf8) else {
             throw SwiftyRSAError.tagEncodingFailed

--- a/SwiftyRSA.xcodeproj/project.pbxproj
+++ b/SwiftyRSA.xcodeproj/project.pbxproj
@@ -413,12 +413,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1000;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1140;
 				ORGANIZATIONNAME = Scoop;
 				TargetAttributes = {
 					A0D4C96F0225BD9340375C73B5AFD981 = {
 						CreatedOnToolsVersion = 6.3;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1140;
 					};
 					C057921921545C790057F401 = {
 						CreatedOnToolsVersion = 10.0;
@@ -434,17 +434,18 @@
 					};
 					C076F53C1DADEB90006AF5DB = {
 						CreatedOnToolsVersion = 8.0;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1140;
 						ProvisioningStyle = Manual;
 					};
 				};
 			};
 			buildConfigurationList = 2233014209832DED84FCD99414E4EFC3 /* Build configuration list for PBXProject "SwiftyRSA" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = E64764973D14B1FBBFB2CE3C0E1BAE8A;
 			productRefGroup = 345E780D70779A01AA3BAA5CB4CE6558 /* Products */;
@@ -653,6 +654,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -660,6 +662,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -920,6 +923,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "SwiftyRSATests-Swift.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -941,6 +945,7 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "SwiftyRSATests-Swift.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -948,6 +953,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -1020,6 +1026,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/SwiftyRSA.xcodeproj/xcshareddata/xcschemes/SwiftyRSA iOS.xcscheme
+++ b/SwiftyRSA.xcodeproj/xcshareddata/xcschemes/SwiftyRSA iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,8 +40,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A0D4C96F0225BD9340375C73B5AFD981"
+            BuildableName = "SwiftyRSA.framework"
+            BlueprintName = "SwiftyRSA iOS"
+            ReferencedContainer = "container:SwiftyRSA.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -54,17 +63,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "A0D4C96F0225BD9340375C73B5AFD981"
-            BuildableName = "SwiftyRSA.framework"
-            BlueprintName = "SwiftyRSA iOS"
-            ReferencedContainer = "container:SwiftyRSA.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -85,8 +83,6 @@
             ReferencedContainer = "container:SwiftyRSA.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SwiftyRSA.xcodeproj/xcshareddata/xcschemes/SwiftyRSA tvOS.xcscheme
+++ b/SwiftyRSA.xcodeproj/xcshareddata/xcschemes/SwiftyRSA tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C0579237215465040057F401"
+            BuildableName = "SwiftyRSA.framework"
+            BlueprintName = "SwiftyRSA tvOS"
+            ReferencedContainer = "container:SwiftyRSA.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "C0579237215465040057F401"
-            BuildableName = "SwiftyRSA.framework"
-            BlueprintName = "SwiftyRSA tvOS"
-            ReferencedContainer = "container:SwiftyRSA.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:SwiftyRSA.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SwiftyRSA.xcodeproj/xcshareddata/xcschemes/SwiftyRSA watchOS.xcscheme
+++ b/SwiftyRSA.xcodeproj/xcshareddata/xcschemes/SwiftyRSA watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:SwiftyRSA.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -60,8 +58,6 @@
             ReferencedContainer = "container:SwiftyRSA.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Tests/TestUtils.swift
+++ b/Tests/TestUtils.swift
@@ -73,7 +73,7 @@ struct TestError: Error {
         if status != errSecSuccess {
              XCTFail("Couldn't create random data")
         }
-        return Data(bytes: randomBytes)
+        return Data(randomBytes)
     }
     
     static func assertThrows(type: SwiftyRSAError, file: StaticString = #file, line: UInt = #line, block: () throws ->  Void) {


### PR DESCRIPTION
PR addresses a crash related to `ClearMessage` and `EncryptedMessage`.
Mirroring: https://github.com/TakeScoop/SwiftyRSA/pull/184/files